### PR TITLE
Add Streamlit visualization app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # dads_5001_condo
+
+This repository contains cleaned condominium rental data and a simple Streamlit
+app for visualizing the information.
+
+## Streamlit Visualization
+
+1. Install the required packages (pandas, streamlit and plotly). You can use
+   `pip`:
+
+   ```bash
+   pip install pandas streamlit plotly
+   ```
+
+2. Run the app with:
+
+   ```bash
+   streamlit run streamlit_app.py
+   ```
+
+The interface lets you select a bedroom count and price range to explore the
+relationship between the number of bedrooms and rental price.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,35 @@
+import streamlit as st
+import pandas as pd
+import plotly.express as px
+
+# Load data
+@st.cache_data
+def load_data(path: str) -> pd.DataFrame:
+    return pd.read_csv(path)
+
+df = load_data('data_cleaned.csv')
+
+st.title('Condo Rent Visualization')
+
+# Filters
+bed_options = sorted(df['rent_cd_bed'].dropna().unique())
+selected_bed = st.selectbox('Number of Bedrooms', options=bed_options)
+
+price_min, price_max = int(df['rent_cd_price'].min()), int(df['rent_cd_price'].max())
+price_range = st.slider('Price Range', min_value=price_min, max_value=price_max,
+                        value=(price_min, price_max))
+
+filtered = df[(df['rent_cd_bed'] == selected_bed) &
+              (df['rent_cd_price'].between(*price_range))]
+
+fig = px.scatter(
+    filtered,
+    x='rent_cd_bed',
+    y='rent_cd_price',
+    color='rent_cd_bed',
+    hover_data=['rent_cd_address'],
+    labels={'rent_cd_bed': 'Bedrooms', 'rent_cd_price': 'Price'},
+    title='Price vs Bedrooms'
+)
+
+st.plotly_chart(fig, use_container_width=True)


### PR DESCRIPTION
## Summary
- add a Streamlit app to visualize rent data
- document how to launch the visualization

## Testing
- `python3 -m py_compile streamlit_app.py`
- `streamlit run streamlit_app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492a48a0b0832c86c6e2e13883e6c4